### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Processes emoji in markdown and inlines `<img>` tags with the corresponding base64 corresponding of the image.
 
-See all available [emoji](emoji.md)
+See all available [emoji](https://github.com/matchilling/gatsby-remark-emojis/blob/master/emoji.md)
 
 ## Install
 


### PR DESCRIPTION
This README is used to automatically generate the plugin page in https://www.gatsbyjs.org/packages/gatsby-remark-emojis/

If you click the "See available emoji" link there, it doesn't work because it's a relative link. By changing the link to absolute path it will work in all places including there.