### PR TITLE
Avoid pattern mismatch, add option to specify escape character

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,15 @@
+version: 2.1
+
+jobs:
+  build:
+    working_directory: ~/gatsby-remark-emojis
+    docker:
+      - image: circleci/node:10.15.3
+    steps:
+      - checkout
+      - run:
+          name: Run npm install
+          command: npm install
+      - run:
+          name: Run npm test
+          command: npm test

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ plugins: [
         options: {
           // Deactivate the plugin globally (default: true)
           active : true,
+          // Require blank space on both sides of emoji (default false)
+          requireWhiteSpace: false,
           // Add a custom css class
           class  : 'emoji-icon',
           // Select the size (available size: 16, 24, 32, 64)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gatsby-remark-emojis
+# Gatsby Remark Emojis [![CircleCI](https://circleci.com/gh/matchilling/gatsby-remark-emojis.svg?style=svg)](https://circleci.com/gh/matchilling/gatsby-remark-emojis)
 
 Processes emoji in markdown and inlines `<img>` tags with the corresponding base64 corresponding of the image.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ plugins: [
           requireWhiteSpace: false,
           // Add a custom css class
           class  : 'emoji-icon',
+          // In order to avoid pattern mismatch you can specify
+          // an escape character which will be prepended to the
+          // actual pattern (e.g. `#:poop:`).
+          escapeCharacter : '#', // (default: '')
           // Select the size (available size: 16, 24, 32, 64)
           size   : 64,
           // Add custom styles

--- a/index.js
+++ b/index.js
@@ -6,11 +6,14 @@ module.exports = {
 
     if (!active) return Promise.resolve();
 
-    const classAttribute = pluginOptions.class
-            ? ` class="${pluginOptions.class}" `
-            : "",
-          size = pluginOptions.size || 64,
-          styleAttribute = Object.keys(pluginOptions.styles || {})
+    const classAttribute = pluginOptions && pluginOptions.class
+            ? `class="${pluginOptions.class}"`
+            : null,
+          escapeCharacter = pluginOptions && pluginOptions.hasOwnProperty('escapeCharacter')
+                  ? pluginOptions.escapeCharacter
+                  : '',
+          size = pluginOptions && pluginOptions.size ? pluginOptions.size : 64,
+          styleAttribute = Object.keys(pluginOptions && pluginOptions.styles || {})
             .filter(key => '_PARENT' !== key)
             .map((key) => `${key}: ${pluginOptions.styles[key]}`)
             .join('; '),
@@ -18,8 +21,8 @@ module.exports = {
 
     Object.keys(emojis).forEach((key) => {
       const emoji = emojis[key],
-            pattern = pluginOptions.requireWhiteSpace ? new RegExp(`(?<=[\\s\\n])${emoji.pattern}(?:[\\s\\n])`, 'g') : new RegExp(emoji.pattern, 'g'),
-            replacement = `<img${classAttribute} alt="emoji-${key}" data-icon="emoji-${key}" style="${styleAttribute}" src="data:image/png;base64, ${emojis[key].data}" title="emoji-${key}" />`;
+            pattern = new RegExp(`${escapeCharacter}${emoji.pattern}`, 'g'),
+            replacement = (classAttribute ? `<img ${classAttribute} ` : '<img ') + `alt="emoji-${key}" data-icon="emoji-${key}" style="${styleAttribute}" src="data:image/png;base64, ${emojis[key].data}" title="emoji-${key}" />`;
 
       markdownNode.internal.content = markdownNode.internal.content.replace(
         pattern,

--- a/index.js
+++ b/index.js
@@ -1,18 +1,16 @@
 const source = (size) => require(`./resource/emoji.${size}.json`);
 
 module.exports = {
-  mutateSource: ({ markdownNode }, pluginOptions) => {
-    const active = undefined !== pluginOptions
-            && pluginOptions.hasOwnProperty('active')
-            && false !== pluginOptions.active;
+  mutateSource: ({ markdownNode }, pluginOptions = {}) => {
+    const active = !!pluginOptions.active;
 
     if (!active) return Promise.resolve();
 
-    const classAttribute = pluginOptions && pluginOptions.class
-            ? `class="${pluginOptions.class}"`
-            : null,
-          size = pluginOptions && pluginOptions.size ? pluginOptions.size : 64,
-          styleAttribute = Object.keys(pluginOptions && pluginOptions.styles || {})
+    const classAttribute = pluginOptions.class
+            ? ` class="${pluginOptions.class}" `
+            : "",
+          size = pluginOptions.size || 64,
+          styleAttribute = Object.keys(pluginOptions.styles || {})
             .filter(key => '_PARENT' !== key)
             .map((key) => `${key}: ${pluginOptions.styles[key]}`)
             .join('; '),
@@ -20,9 +18,8 @@ module.exports = {
 
     Object.keys(emojis).forEach((key) => {
       const emoji = emojis[key],
-            pattern = new RegExp(emoji.pattern, 'g'),
-            replacement = (classAttribute ? `<img ${classAttribute} ` : '<img ') + `alt="emoji-${key}" data-icon="emoji-${key}" style="${styleAttribute}" src="data:image/png;base64, ${emojis[key].data}" title="emoji-${key}" />`;
-
+            pattern = pluginOptions.requireWhiteSpace ? new RegExp(`(?<=[\\s\\n])${emoji.pattern}(?:[\\s\\n])`, 'g') : new RegExp(emoji.pattern, 'g'),
+            replacement = `<img${classAttribute} alt="emoji-${key}" data-icon="emoji-${key}" style="${styleAttribute}" src="data:image/png;base64, ${emojis[key].data}" title="emoji-${key}" />`;
 
       markdownNode.internal.content = markdownNode.internal.content.replace(
         pattern,

--- a/index.spec.js
+++ b/index.spec.js
@@ -61,16 +61,8 @@ describe(`${pkg.name}@${pkg.version}`, () => {
         };
         options = {
           active : true,
-          class  : 'emoji-icon',
-          size   : 16,
-          styles : {
-            display      : 'inline',
-            margin       : '0',
-            'margin-top' : '1px',
-            position     : 'relative',
-            top          : '5px',
-            width        : '25px'
-          }
+          escapeCharacter : '',
+          size   : 16
         };
       });
 
@@ -84,43 +76,64 @@ describe(`${pkg.name}@${pkg.version}`, () => {
           });
         });
       });
+
+      describe('escapeCharacter', () => {
+        it('does not change source if pattern not found', async () => {
+          options.escapeCharacter = '#';
+          markdownNode.internal.content = new String('Some content :100:!');
+
+          await component.mutateSource({ markdownNode }, options);
+
+          assert.equal(
+            markdownNode.internal.content,
+            'Some content :100:!'
+          );
+        });
+
+        it('prepends the emoji pattern and renders an emoji correctly', async () => {
+          options.escapeCharacter = '#';
+          markdownNode.internal.content = new String('Some content #:100:!');
+
+          await component.mutateSource({ markdownNode }, options);
+
+          assert.equal(
+            markdownNode.internal.content,
+            'Some content <img alt="emoji-100" data-icon="emoji-100" style="" src="data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAACClBMVEUAAADgAADNAADPAADKAADMAACjAADOAADHAADEAABqAADdAADGAADnAAC9AADDAADxAAC0AADLAADBAADCAADpAADZAADaAADJAAC8AACpAADfAADFAAD/AADiAAC/AADVAADUAADTAAC+AADIAADbAAC2AADQAACPAADbAADSAADMAADVAADNAADOAADJAADHAADOAADOAADHAADHAADLAADSAADIAADEAADIAADEAADIAADKAADHAADDAADIAADFAADPAADIAADEAADEAADGAADDAADJAADHAADFAADCAADLAADFAAC+AADMAADHAADFAADGAADFAADFAADKAADGAADEAADJAADJAADEAADLAADFAADHAADEAAD/AADHAADGAADDAADiAADGAADDAAD/AADIAADDAADFAADFAADMAADFAADGAADFAADKAADEAADCAADOAADGAADCAADHAADEAADEAADDAADIAADDAADDAADDAADJAADEAAC4AADIAADIAADJAADKAADIAADIAADJAADFAADIAADFAADEAADGAADDAADLAADFAADQAADGAADFAADIAADKAADGAADJAADXAADOAADKAADHAADGAADFAADFAADEAADEAADGAADIAADPAADGAADEAADEAADEAADDAADDAADEAAC3AADBAADMAADEAAC+AAD////BXOMGAAAArXRSTlMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUKEgcxFGR9IhySeDIQhsmAsFhyiZFEcBaU6LS2SjiruihJiQETUbmWrw5U458CbYA8sIeJApbkdAaqUwGJfXyLRbyomGy2GB+3MUO+vVwvoqlHUY8CKUc+UE8xaVF3tZJZBDYXEWRWQ0hJOwUqYI+vt7SmloEyIJybaj8kEwkEAQQRBC+ZeWsAAAABYktHRK0gYsIdAAAAB3RJTUUH4woMBxQZE+gNhQAAAQNJREFUGNNjYGBgZGJmYWXTZOfQ0mbg5GJg4OZh19HV0zcwNDI2MeXlY2DgZzEzt7C0sraxtbN3EBBkYGB3dHJ2cXVz9/D08vbx5WBgEPLzDwgMCg4JDQuPiGQRZmBgZYmKjomNi09ITEpOERFmEBVLTUvPyMzKzsnNyy/gZ2YQZy8sKi4pLSuvqKyqlpCUYpCWqamtk61vaGxqbpHjkWdgUOBrbTNrz+mIDuvs6uZUZGBQUu7p7eufMHHS5JIpfipKDAwsilOnTZ8xc9bsOXPnzedkYmBQZVqwcNHiJUuXLV+xUo1blgHosFWr14hw8nPKSMpwqGsABVhZZYQ5ePgZcAEAK4I+IgrMGqkAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDQtMDZUMjA6MjA6NDMrMDA6MDBiSxACAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTA0LTA2VDIwOjIwOjQzKzAwOjAwExaovgAAAABJRU5ErkJggg==" title="emoji-100" />!'
+          );
+        });
+      });
+
       describe('class', () => {
         it('adds a "class" attribute', async () => {
-          await component.mutateSource({ markdownNode }, options);
+          await component.mutateSource({ markdownNode }, {
+            ...options,
+            class  : 'emoji-icon'
+          });
 
           sinon.assert.calledOnce(content.replace);
           assert.include(markdownNode.internal.content, 'class="emoji-icon"');
         });
       });
+
       describe('styles', () => {
         it('adds a "style" attribute', async () => {
-          await component.mutateSource({ markdownNode }, options);
+          await component.mutateSource({ markdownNode }, {
+            ...options,
+            styles : {
+              display      : 'inline',
+              margin       : '0',
+              'margin-top' : '1px',
+              position     : 'relative',
+              top          : '5px',
+              width        : '25px'
+            }
+          });
 
           sinon.assert.calledOnce(content.replace);
           assert.include(
             markdownNode.internal.content,
             'style="display: inline; margin: 0; margin-top: 1px; position: relative; top: 5px; width: 25px"'
           );
-        });
-      });
-      describe('word break', () => {
-        it('does not mutate within a word if requireWhiteSpace is true', async () => {
-          options.requireWhiteSpace = true;
-          await component.mutateSource({ markdownNode }, options);
-
-          sinon.assert.calledOnce(content.replace);
-          // assert.equal(markdownNode.internal.content, content);
-        });
-
-        it('does mutate with a word break if requireWhiteSpace is true', async () => {
-          options.requireWhiteSpace = true;
-          const contentWithSpace = new String('Some content :100: !');
-          sinon.spy(contentWithSpace, 'replace');
-          markdownNode.internal.content = contentWithSpace;
-          await component.mutateSource({ markdownNode }, options);
-
-          sinon.assert.calledOnce(contentWithSpace.replace);
-          assert.include(markdownNode.internal.content, 'img');
         });
       });
     });

--- a/index.spec.js
+++ b/index.spec.js
@@ -103,6 +103,26 @@ describe(`${pkg.name}@${pkg.version}`, () => {
           );
         });
       });
+      describe('word break', () => {
+        it('does not mutate within a word if requireWhiteSpace is true', async () => {
+          options.requireWhiteSpace = true;
+          await component.mutateSource({ markdownNode }, options);
+
+          sinon.assert.calledOnce(content.replace);
+          // assert.equal(markdownNode.internal.content, content);
+        });
+
+        it('does mutate with a word break if requireWhiteSpace is true', async () => {
+          options.requireWhiteSpace = true;
+          const contentWithSpace = new String('Some content :100: !');
+          sinon.spy(contentWithSpace, 'replace');
+          markdownNode.internal.content = contentWithSpace;
+          await component.mutateSource({ markdownNode }, options);
+
+          sinon.assert.calledOnce(contentWithSpace.replace);
+          assert.include(markdownNode.internal.content, 'img');
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
There are cases in which :...: may occur in, for example, a URL where inserting an emoji would break a link. This adds an option to the plugin to replace only if the emoji pattern is surrounded by whitespace. This should be false by default, as it incurs a performance penalty.

Notes on the code: using the boundary assertion (\b) would be more performant but doesn't work for emoji patterns because : is a non-word character. This implementation uses lookbehinds, which are relatively new to Node. An alternative is to replace the lookbehind with `([\s\n])` and add `$1` to the `replacement` if `requireWhiteSpace` is `true`.